### PR TITLE
Add read-only /api/resources endpoint

### DIFF
--- a/backend/src/main/java/com/example/app/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/app/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.app.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -30,6 +31,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/resources/**").permitAll()
                 .anyRequest().authenticated()
             ).addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/example/app/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/app/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/resources/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/resources").permitAll()
                 .anyRequest().authenticated()
             ).addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/example/app/resource/Resource.java
+++ b/backend/src/main/java/com/example/app/resource/Resource.java
@@ -1,0 +1,65 @@
+package com.example.app.resource;
+
+import java.time.Instant;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Persistence model (the "M" in MVC) for a shared course resource.
+ * This entity is never exposed directly over HTTP — {@link ResourceResponse}
+ * is the API-facing type, keeping the web layer decoupled from the schema.
+ */
+@Entity
+@Table(name = "resources")
+public class Resource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String course;
+    private String uploader;
+    private Instant uploadedAt;
+    private String downloadUrl;
+
+    /** Required no-arg constructor for JPA. */
+    protected Resource() {
+    }
+
+    public Resource(String title, String course, String uploader, Instant uploadedAt, String downloadUrl) {
+        this.title = title;
+        this.course = course;
+        this.uploader = uploader;
+        this.uploadedAt = uploadedAt;
+        this.downloadUrl = downloadUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCourse() {
+        return course;
+    }
+
+    public String getUploader() {
+        return uploader;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public String getDownloadUrl() {
+        return downloadUrl;
+    }
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceController.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceController.java
@@ -1,0 +1,27 @@
+package com.example.app.resource;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller (the "C" in MVC) exposing read access to course resources.
+ * Consumed by the frontend Resources page via {@code GET /api/resources}.
+ */
+@RestController
+@RequestMapping("/api/resources")
+public class ResourceController {
+
+    private final ResourceService resourceService;
+
+    public ResourceController(ResourceService resourceService) {
+        this.resourceService = resourceService;
+    }
+
+    @GetMapping
+    public List<ResourceResponse> getResources() {
+        return resourceService.getAllResources();
+    }
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceRepository.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceRepository.java
@@ -1,0 +1,10 @@
+package com.example.app.resource;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link Resource}. Provides {@code findAll}, {@code save},
+ * {@code count}, etc. out of the box.
+ */
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceResponse.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceResponse.java
@@ -1,0 +1,31 @@
+package com.example.app.resource;
+
+import java.time.Instant;
+
+/**
+ * API-facing DTO returned by {@link ResourceController}. Its component names map
+ * one-to-one onto the TypeScript {@code Resource} type consumed by the frontend
+ * (PR #71): { id, title, course, uploader, uploadedAt, downloadUrl }.
+ *
+ * <p>Keeping this separate from the {@link Resource} entity decouples the public
+ * contract from the database schema — the entity can change without breaking the API.
+ */
+public record ResourceResponse(
+        Long id,
+        String title,
+        String course,
+        String uploader,
+        Instant uploadedAt,
+        String downloadUrl) {
+
+    /** Maps a persistence entity onto its API representation. */
+    public static ResourceResponse from(Resource resource) {
+        return new ResourceResponse(
+                resource.getId(),
+                resource.getTitle(),
+                resource.getCourse(),
+                resource.getUploader(),
+                resource.getUploadedAt(),
+                resource.getDownloadUrl());
+    }
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceSeeder.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceSeeder.java
@@ -1,0 +1,35 @@
+package com.example.app.resource;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Seeds a small set of sample resources on startup so the frontend Resources
+ * page shows real backend data. The insert is guarded by a count check, so it
+ * is idempotent across restarts (which reuse the same schema via ddl-auto=update).
+ */
+@Configuration
+public class ResourceSeeder {
+
+    @Bean
+    CommandLineRunner seedResources(ResourceRepository repository) {
+        return args -> {
+            if (repository.count() > 0) {
+                return;
+            }
+            repository.saveAll(List.of(
+                    new Resource("Midterm 1 Practice Problems", "COSC 121", "Jane Doe",
+                            Instant.parse("2026-06-18T14:30:00Z"), "#"),
+                    new Resource("Final Exam Review Sheet", "MATH 151", "John Smith",
+                            Instant.parse("2026-06-20T09:00:00Z"), "#"),
+                    new Resource("Lab 3 Solutions", "PHYS 101", "Alice Chen",
+                            Instant.parse("2026-06-22T16:45:00Z"), "#"),
+                    new Resource("Regression Cheat Sheet", "STAT 260", "Sam Lee",
+                            Instant.parse("2026-06-24T11:15:00Z"), "#")));
+        };
+    }
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceSeeder.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceSeeder.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,11 +12,16 @@ import org.springframework.context.annotation.Configuration;
  * Seeds a small set of sample resources on startup so the frontend Resources
  * page shows real backend data. The insert is guarded by a count check, so it
  * is idempotent across restarts (which reuse the same schema via ddl-auto=update).
+ *
+ * <p>Seeding is enabled by default but can be turned off — e.g. in production, to
+ * avoid injecting placeholder data into the real database — by setting
+ * {@code app.seed-sample-resources=false}.
  */
 @Configuration
 public class ResourceSeeder {
 
     @Bean
+    @ConditionalOnProperty(name = "app.seed-sample-resources", havingValue = "true", matchIfMissing = true)
     CommandLineRunner seedResources(ResourceRepository repository) {
         return args -> {
             if (repository.count() > 0) {

--- a/backend/src/main/java/com/example/app/resource/ResourceService.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceService.java
@@ -1,0 +1,14 @@
+package com.example.app.resource;
+
+import java.util.List;
+
+/**
+ * Service abstraction for reading resources. The controller depends on this
+ * interface rather than a concrete class, keeping the web layer loosely coupled
+ * from the persistence implementation.
+ */
+public interface ResourceService {
+
+    /** Returns all resources as API response DTOs. */
+    List<ResourceResponse> getAllResources();
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceServiceImpl.java
@@ -1,0 +1,26 @@
+package com.example.app.resource;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Default {@link ResourceService} implementation. Delegates persistence to the
+ * repository and maps entities to {@link ResourceResponse} DTOs.
+ */
+@Service
+public class ResourceServiceImpl implements ResourceService {
+
+    private final ResourceRepository repository;
+
+    public ResourceServiceImpl(ResourceRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<ResourceResponse> getAllResources() {
+        return repository.findAll().stream()
+                .map(ResourceResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/example/app/resource/ResourceServiceImpl.java
+++ b/backend/src/main/java/com/example/app/resource/ResourceServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.app.resource;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Default {@link ResourceService} implementation. Delegates persistence to the
@@ -18,6 +19,7 @@ public class ResourceServiceImpl implements ResourceService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ResourceResponse> getAllResources() {
         return repository.findAll().stream()
                 .map(ResourceResponse::from)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,6 +16,11 @@ spring.jpa.show-sql=true
 spring.security.user.name=admin
 spring.security.user.password=PLACEHOLDER
 
+# ── Sample data ───────────────────────────────
+# Seeds placeholder course resources on startup for local/demo use.
+# Set to false in production to keep sample data out of the real database.
+app.seed-sample-resources=true
+
 # ── JWT ──────────────────────────────────
 spring.jwt.secret.access=PLACEHOLDER
 spring.jwt.secret.refresh=PLACEHOLDER

--- a/backend/src/test/java/com/example/app/resource/ResourceApiIntegrationTest.java
+++ b/backend/src/test/java/com/example/app/resource/ResourceApiIntegrationTest.java
@@ -2,10 +2,15 @@ package com.example.app.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
@@ -16,14 +21,27 @@ import org.springframework.test.web.servlet.client.RestTestClient;
  *   <li>it returns a JSON array, and</li>
  *   <li>each element carries exactly the fields the TypeScript {@code Resource} type expects.</li>
  * </ul>
- * The seeded sample data confirms the controller/service/repository are wired together.
+ *
+ * <p>Sample-data seeding is disabled here and the test inserts its own fixture, so it
+ * owns its data and does not depend on the {@link ResourceSeeder} being enabled.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
+@TestPropertySource(properties = "app.seed-sample-resources=false")
 class ResourceApiIntegrationTest {
 
     @Value("${local.server.port}")
     private int port;
+
+    @Autowired
+    private ResourceRepository repository;
+
+    @BeforeEach
+    void seedFixture() {
+        repository.deleteAll();
+        repository.save(new Resource("Fixture Study Guide", "COSC 111", "Test Uploader",
+                Instant.parse("2026-01-02T03:04:05Z"), "https://example.com/guide.pdf"));
+    }
 
     @Test
     void getResources_isPublicAndReturnsFrontendContract() {
@@ -47,8 +65,8 @@ class ResourceApiIntegrationTest {
                             .contains("\"uploader\"")
                             .contains("\"uploadedAt\"")
                             .contains("\"downloadUrl\"");
-                    // Seeded data flows through the full stack.
-                    assertThat(body).contains("Midterm 1 Practice Problems");
+                    // The fixture this test inserted flows through the full stack.
+                    assertThat(body).contains("Fixture Study Guide");
                 });
     }
 }

--- a/backend/src/test/java/com/example/app/resource/ResourceApiIntegrationTest.java
+++ b/backend/src/test/java/com/example/app/resource/ResourceApiIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.example.app.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+/**
+ * End-to-end test of the resources API over a real HTTP server (H2-backed test
+ * profile). Verifies the three things the frontend (PR #71) relies on:
+ * <ul>
+ *   <li>{@code GET /api/resources} is publicly reachable (security {@code permitAll}),</li>
+ *   <li>it returns a JSON array, and</li>
+ *   <li>each element carries exactly the fields the TypeScript {@code Resource} type expects.</li>
+ * </ul>
+ * The seeded sample data confirms the controller/service/repository are wired together.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ResourceApiIntegrationTest {
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Test
+    void getResources_isPublicAndReturnsFrontendContract() {
+        RestTestClient client = RestTestClient.bindToServer()
+                .baseUrl("http://localhost:" + port)
+                .build();
+
+        client.get().uri("/api/resources")
+                .exchange()
+                // Reachable without a JWT -> the permitAll rule is in effect.
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .value(body -> {
+                    assertThat(body).isNotNull();
+                    assertThat(body.trim()).startsWith("[");
+                    // The exact field names the frontend deserializes.
+                    assertThat(body)
+                            .contains("\"id\"")
+                            .contains("\"title\"")
+                            .contains("\"course\"")
+                            .contains("\"uploader\"")
+                            .contains("\"uploadedAt\"")
+                            .contains("\"downloadUrl\"");
+                    // Seeded data flows through the full stack.
+                    assertThat(body).contains("Midterm 1 Practice Problems");
+                });
+    }
+}

--- a/backend/src/test/java/com/example/app/resource/ResourceServiceImplTest.java
+++ b/backend/src/test/java/com/example/app/resource/ResourceServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.example.app.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the service layer. The repository is mocked so these tests
+ * stay fast and free of any Spring / database coupling.
+ */
+@ExtendWith(MockitoExtension.class)
+class ResourceServiceImplTest {
+
+    @Mock
+    private ResourceRepository repository;
+
+    @InjectMocks
+    private ResourceServiceImpl service;
+
+    @Test
+    void getAllResources_mapsEntitiesToResponseDtos() {
+        Resource entity = new Resource(
+                "Midterm 1 Practice Problems", "COSC 121", "Jane Doe",
+                Instant.parse("2026-06-18T14:30:00Z"), "#");
+        when(repository.findAll()).thenReturn(List.of(entity));
+
+        List<ResourceResponse> result = service.getAllResources();
+
+        assertThat(result).hasSize(1);
+        ResourceResponse dto = result.get(0);
+        assertThat(dto.title()).isEqualTo("Midterm 1 Practice Problems");
+        assertThat(dto.course()).isEqualTo("COSC 121");
+        assertThat(dto.uploader()).isEqualTo("Jane Doe");
+        assertThat(dto.uploadedAt()).isEqualTo(Instant.parse("2026-06-18T14:30:00Z"));
+        assertThat(dto.downloadUrl()).isEqualTo("#");
+    }
+
+    @Test
+    void getAllResources_returnsEmptyListWhenNoResources() {
+        when(repository.findAll()).thenReturn(List.of());
+
+        assertThat(service.getAllResources()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the backend `GET /api/resources` endpoint that the frontend Resources page (#71) depends on. Previously the backend had no resources endpoint at all, so the frontend silently fell back to hardcoded sample data.

Follows an MVC structure with low coupling:

| Layer | Type |
| --- | --- |
| Model | `Resource` (JPA entity — never exposed over HTTP) |
| DTO | `ResourceResponse` (record; decouples the API contract from the schema) |
| Repository | `ResourceRepository` (Spring Data) |
| Service | `ResourceService` interface + `ResourceServiceImpl` |
| Controller | `ResourceController` → `GET /api/resources` |

The DTO's fields map one-to-one onto the frontend's TypeScript `Resource` type: `{ id, title, course, uploader, uploadedAt, downloadUrl }`.

## Details

- **Security:** `SecurityConfig` opens `GET /api/resources/**` via a scoped `permitAll()` (the page is public and unauthenticated); every other route stays `authenticated()`.
- **Sample data:** `ResourceSeeder` inserts a few rows on startup so the page shows real data. The insert is guarded by a count check (idempotent across restarts) and gated behind `app.seed-sample-resources` (default on) — set it to `false` in production to keep placeholder data out of the real database.
- **Read path:** `getAllResources()` is `@Transactional(readOnly = true)`.

## Testing

Developed test-first (TDD):

- `ResourceServiceImplTest` — Mockito unit test for entity → DTO mapping, no Spring/DB.
- `ResourceApiIntegrationTest` — `@SpringBootTest(RANDOM_PORT)` over a real HTTP server (Framework 7 `RestTestClient`) asserting the endpoint is publicly reachable, returns a JSON array, and carries the exact fields the frontend expects.

Also verified manually against a live PostgreSQL instance: `GET /api/resources` returns `200` with the seeded rows, and a protected route returns `403` (confirming the `permitAll` is correctly scoped).

## Notes

- Requires a running PostgreSQL matching `application.properties`.
- Built and tested on Java 25 / Spring Boot 4.0.6. Note Boot 4 relocated the web test slices, so the integration test uses `RestTestClient` rather than the removed `@WebMvcTest` / `TestRestTemplate`.